### PR TITLE
Add second email to the CoC

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,4 +1,3 @@
-
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
@@ -33,7 +32,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## [](https://github.com/catalyst-network/Community/Contributor-Code-of-Conduct/Contributor-Code-of-Conduct#enforcement)Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project lead at [nshcore@protonmail.ch](nshcore@protonmail.ch). The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project lead at [nshcore@protonmail.ch](mailto:nshcore@protonmail.ch), which goes to @nshCore, or to [richard@maintainer.io](mailto:richard@maintainer.io), which goes to @RichardLit. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 


### PR DESCRIPTION
This adds my email to the Code of Conduct. Having two emails means that people may feel safer reporting on anyone in the community, as it gives them an option, especially in cases where the offender may have been me or @nshCore (hopefully, this never happens). It would be a good idea to set up community@catalystnet.org as an alias which can go to the community committee, and to add this email here when that is set up, as well.